### PR TITLE
make this module require anything greater then 2.23

### DIFF
--- a/modules/iam-assumable-role-with-oidc/versions.tf
+++ b/modules/iam-assumable-role-with-oidc/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "0.13.5"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23"
   }
 }


### PR DESCRIPTION
Need to upgrade the AWS provider for EFS and I think this constraint is breaking things