### PR TITLE
IAM Modules - AWS Provider Update (>=2.23)

### DIFF
--- a/modules/iam-assumable-role/versions.tf
+++ b/modules/iam-assumable-role/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "0.13.5"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23"
   }
 }

--- a/modules/iam-assumable-roles-with-saml/versions.tf
+++ b/modules/iam-assumable-roles-with-saml/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23"
   }
 }

--- a/modules/iam-assumable-roles/versions.tf
+++ b/modules/iam-assumable-roles/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23"
   }
 }

--- a/modules/iam-group-with-assumable-roles-policy/versions.tf
+++ b/modules/iam-group-with-assumable-roles-policy/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23"
   }
 }

--- a/modules/iam-group-with-policies/versions.tf
+++ b/modules/iam-group-with-policies/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23"
   }
 }


### PR DESCRIPTION
- Updating required_providers flag on multiple modules to support aws >= 2.25